### PR TITLE
Move PGP key request to port 80 so that it can traverse the firewall

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@ apt_repository "phusion" do
   uri           apt_uri
   distribution  node.lsb.codename
   components    ['main']
-  keyserver     "keyserver.ubuntu.com:80"
+  keyserver     "hkp://keyserver.ubuntu.com:80"
   key           "561F9B9CAC40B2F7"
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@ apt_repository "phusion" do
   uri           apt_uri
   distribution  node.lsb.codename
   components    ['main']
-  keyserver     "keyserver.ubuntu.com"
+  keyserver     "keyserver.ubuntu.com:80"
   key           "561F9B9CAC40B2F7"
 end
 


### PR DESCRIPTION
Request to install Phusion PGP key does not make it through default port 11371 was blocked by corporate firewall, moved to port 80 which is open.