### PR TITLE
Add more global performance tuning options

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -7,7 +7,7 @@ DEPENDENCIES
 
 GRAPH
   apt (2.4.0)
-  nginx_passenger (0.5.5)
+  nginx_passenger (0.5.7)
     apt (>= 0.0.0)
     ssl_certificate (>= 0.0.0)
   nginx_passenger-test (0.0.1)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ nginx packages.
 * __sites\_dir:__ Directory in which to write our virtualhost files. Defaults
     to `/etc/nginx/sites-enabled`.
 * __nginx\_workers:__ NGINX worker count. Defaults to 4.
+* __nginx\_connections:__ NGINX worker connection count. Defaults to 768.
 * __catch\_default`:__ If true, add an empty virtualhost file that catches all
     requests for hosts other than the ones explicitly registered in virtualhost
     files. Defaults to false.

--- a/README.md
+++ b/README.md
@@ -34,10 +34,13 @@ nginx packages.
 * __certs\_dir:__ Directory for cert files. Defaults to `/etc/nginx/certs`
 * __ruby:__ Default Ruby interpreter. Defaults to `/usr/bin/ruby`
 * __max\_pool\_size`:__ Max number of passenger instances. Defaults to 8.
+* __min\_instances:__ Passenger config for default minimum instances of all apps. Defaults to 2.
+* __pool\_idle\_time:__ Max number of seconds a Passenger process may be idle. Defaults to 300.
+* __max\_requests:__ Max number of requests a Passenger process will handle. Defaults to 0.
 * __cert\_databag:__ What databag should we look for SSL certs in? Defaults to `ssl_certs`
 * __redirect\_to\_https:__ If a site supports https, should we redirect http
     requests there? Defaults to true.
-* __site\_min\_instances:__ Passenger config for minimum instances of each app. Defaults to 2.
+* __site\_min\_instances:__ Passenger config for minimum instances of each app. Overrides default `min_instances`. Defaults to 2.
 * __site\_max\_body\_size:__ Maximum body size for uploads. Defaults to `8M`
 * __keep\_env\_path:__ Tell nginx to pass the PATH environment variable through. Defaults to `true`
 * __default\_log\_format:__ What logging format should be used? Defaults to "combined".

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ nginx packages.
 * __certs\_dir:__ Directory for cert files. Defaults to `/etc/nginx/certs`
 * __ruby:__ Default Ruby interpreter. Defaults to `/usr/bin/ruby`
 * __max\_pool\_size`:__ Max number of passenger instances. Defaults to 8.
+* __max\_instances\_per\_app:__ Max number of passenger instances for a single app. Defaults to 0 (unlimited).
 * __min\_instances:__ Passenger config for default minimum instances of all apps. Defaults to 2.
 * __pool\_idle\_time:__ Max number of seconds a Passenger process may be idle. Defaults to 300.
 * __max\_requests:__ Max number of requests a Passenger process will handle. Defaults to 0.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,6 +8,9 @@ default.nginx_passenger.log_dir             = "/var/log/nginx"
 default.nginx_passenger.certs_dir           = "/etc/nginx/certs"
 default.nginx_passenger.ruby                = "/usr/bin/ruby"
 default.nginx_passenger.max_pool_size       = 8
+default.nginx_passenger.min_instances       = 2
+default.nginx_passenger.pool_idle_time      = 300
+default.nginx_passenger.max_requests        = 0
 
 default.nginx_passenger.cert_databag        = "ssl_certs"
 default.nginx_passenger.cert_authority      = "Self Signed"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,6 +2,7 @@ default.nginx_passenger.use_passenger_4     = false
 
 default.nginx_passenger.sites_dir           = "/etc/nginx/sites-enabled"
 default.nginx_passenger.nginx_workers       = 4
+default.nginx.passenger.nginx_connections   = 768
 default.nginx_passenger.catch_default       = false
 
 default.nginx_passenger.log_dir             = "/var/log/nginx"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,26 +1,27 @@
-default.nginx_passenger.use_passenger_4     = false
+default.nginx_passenger.use_passenger_4       = false
 
-default.nginx_passenger.sites_dir           = "/etc/nginx/sites-enabled"
-default.nginx_passenger.nginx_workers       = 4
-default.nginx.passenger.nginx_connections   = 768
-default.nginx_passenger.catch_default       = false
+default.nginx_passenger.sites_dir             = "/etc/nginx/sites-enabled"
+default.nginx_passenger.nginx_workers         = 4
+default.nginx.passenger.nginx_connections     = 768
+default.nginx_passenger.catch_default         = false
 
-default.nginx_passenger.log_dir             = "/var/log/nginx"
-default.nginx_passenger.certs_dir           = "/etc/nginx/certs"
-default.nginx_passenger.ruby                = "/usr/bin/ruby"
-default.nginx_passenger.max_pool_size       = 8
-default.nginx_passenger.min_instances       = 2
-default.nginx_passenger.pool_idle_time      = 300
-default.nginx_passenger.max_requests        = 0
+default.nginx_passenger.log_dir               = "/var/log/nginx"
+default.nginx_passenger.certs_dir             = "/etc/nginx/certs"
+default.nginx_passenger.ruby                  = "/usr/bin/ruby"
+default.nginx_passenger.max_pool_size         = 8
+default.nginx_passenger.max_instances_per_app = 0
+default.nginx_passenger.min_instances         = 2
+default.nginx_passenger.pool_idle_time        = 300
+default.nginx_passenger.max_requests          = 0
 
-default.nginx_passenger.cert_databag        = "ssl_certs"
-default.nginx_passenger.cert_authority      = "Self Signed"
+default.nginx_passenger.cert_databag          = "ssl_certs"
+default.nginx_passenger.cert_authority        = "Self Signed"
 
-default.nginx_passenger.redirect_to_https   = true
-default.nginx_passenger.site_min_instances  = 2
-default.nginx_passenger.site_max_body_size  = "8M"
-default.nginx_passenger.keep_env_path       = true
-default.nginx_passenger.default_log_format  = "combined"
+default.nginx_passenger.redirect_to_https     = true
+default.nginx_passenger.site_min_instances    = 2
+default.nginx_passenger.site_max_body_size    = "8M"
+default.nginx_passenger.keep_env_path         = true
+default.nginx_passenger.default_log_format    = "combined"
 
-default.nginx_passenger.maintenance_page    = nil
-default.nginx_passenger.maintenance_check   = nil
+default.nginx_passenger.maintenance_page      = nil
+default.nginx_passenger.maintenance_check     = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ source_url       "https://github.com/ewr/nginx_passenger-cookbook"
 issues_url       "https://github.com/ewr/nginx_passenger-cookbook/issues"
 description      "Installs/Configures nginx and Passenger on Ubuntu"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.5.6"
+version          "0.5.7"
 
 supports 'ubuntu'
 

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -68,6 +68,9 @@ http {
   passenger_root /usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini;
   passenger_ruby <%= node.nginx_passenger.ruby %>;
   passenger_max_pool_size <%= node.nginx_passenger.max_pool_size %>;
+  passenger_min_instances <%= node.nginx_passenger.min_instances %>;
+  passenger_pool_idle_time <%= node.nginx_passenger.pool_idle_time %>;
+  passenger_max_requests <%= node.nginx_passenger.max_requests %>;
 
   # -- Logging Format -- #
 

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -9,7 +9,7 @@ env PATH;
 <% end %>
 
 events {
-	worker_connections 768;
+	worker_connections <%= node.nginx_passenger.nginx_connections %>;
 	# multi_accept on;
 }
 

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -68,6 +68,7 @@ http {
   passenger_root /usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini;
   passenger_ruby <%= node.nginx_passenger.ruby %>;
   passenger_max_pool_size <%= node.nginx_passenger.max_pool_size %>;
+  passenger_max_instances_per_app <%= node.nginx_passenger.max_instances_per_app %>;
   passenger_min_instances <%= node.nginx_passenger.min_instances %>;
   passenger_pool_idle_time <%= node.nginx_passenger.pool_idle_time %>;
   passenger_max_requests <%= node.nginx_passenger.max_requests %>;


### PR DESCRIPTION
This adds `nginx_connections`, `passenger_min_instances`, `passenger_pool_idle_time`, and `passenger_max_requests` as additional performance tuning options to be added to the `http` block in `nginx.conf`. The `site_min_instances` option will remain as an override for individual sites, but it can be useful to set this value for all sites. Explanation for the default values:

- `nginx_connections` is 768, as it was specified before
- `min_instances` is set to 2 to match the default for `site_min_instances`
- Others are taken from the defaults specified in the [Passenger documentation](https://www.phusionpassenger.com/documentation/Users%20guide%20Nginx.html)