### PR TITLE
Fix error when recipe cannot find fqdn for self signed certs.

### DIFF
--- a/providers/site.rb
+++ b/providers/site.rb
@@ -37,6 +37,7 @@ action :create do
 
     ssl_certificate new_resource.server do
       action :create
+      common_name new_resource.server
       organization node.nginx_passenger.cert_authority
       key_path "#{node.nginx_passenger.certs_dir}/#{new_resource.name}.key"
       cert_path "#{node.nginx_passenger.certs_dir}/#{new_resource.name}.cert"


### PR DESCRIPTION
When the ssl-certificate cookbook cannot figure out a common name it  breaks and causes an error. If we explicity specify the common name we can avoid this issue.

I only have this issue on some hosts however this should fix it across the board.
