### PR TITLE
Run tests on 14.04.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,6 +12,12 @@ platforms:
     disable_upstart:  false
     run_command:      /sbin/init
 
+- name: ubuntu-14.04
+  driver_config:
+    image:            ubuntu-upstart
+    disable_upstart:  false
+    run_command:      /sbin/init
+
 suites:
 - name: default
   run_list:


### PR DESCRIPTION
I have been using this recipe with no problems on ubuntu 14.04 LTS, and I was wondering if you would consider running tests on this version from your kitchen.yml as well? All the current tests pass on both 14.04 and 12.04.
