### PR TITLE
Add ability to use Passenger Enterprise

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -7,7 +7,7 @@ DEPENDENCIES
 
 GRAPH
   apt (2.4.0)
-  nginx_passenger (0.5.7)
+  nginx_passenger (0.5.8)
     apt (>= 0.0.0)
     ssl_certificate (>= 0.0.0)
   nginx_passenger-test (0.0.1)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ nginx packages.
     Also available is `combined_timing`, which adds request time and upstream response time.
 * __maintenance\_page:__ Default path to a maintenance page. Defaults to `nil`
 * __maintenance\_check:__ Default path to a maintenance check. Defaults to `nil`
+* __enterprise\_token:__ Enterprise download token for [Passenger Enterprise](https://www.phusionpassenger.com/enterprise). Defaults to `nil`
+* __enterprise\_license:__ Remote URL to your Passenger Enterprise license file. Defaults to `nil`
 
 ## `nginx_passenger_site`
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,3 +25,6 @@ default.nginx_passenger.default_log_format    = "combined"
 
 default.nginx_passenger.maintenance_page      = nil
 default.nginx_passenger.maintenance_check     = nil
+
+default.nginx_passenger.enterprise_token      = nil
+default.nginx_passenger.enterprise_license    = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ source_url       "https://github.com/ewr/nginx_passenger-cookbook"
 issues_url       "https://github.com/ewr/nginx_passenger-cookbook/issues"
 description      "Installs/Configures nginx and Passenger on Ubuntu"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.5.7"
+version          "0.5.8"
 
 supports 'ubuntu'
 


### PR DESCRIPTION
Passenger Enterprise uses a different repository which requires
authentication, and a license file that needs to be installed on the
server.

This commit adds two new attributes, `enterprise_token` and
`enterprise_license` which need to be set to install Passenger
Enterprise.

Versions 4 and 5 of Passenger are still supported for both OSS and
Enterprise.
