### PR TITLE
Allowing a custom passenger log file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,7 @@ default.nginx_passenger.nginx_connections     = 768
 default.nginx_passenger.catch_default         = false
 
 default.nginx_passenger.log_dir               = "/var/log/nginx"
+default.nginx_passenger.log_file              = "/var/log/nginx/error.log"
 default.nginx_passenger.certs_dir             = "/etc/nginx/certs"
 default.nginx_passenger.ruby                  = "/usr/bin/ruby"
 default.nginx_passenger.max_pool_size         = 8

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,8 +2,6 @@ name             "nginx_passenger"
 maintainer       "Eric Richardson"
 maintainer_email "e@ewr.is"
 license          "BSD"
-source_url       "https://github.com/ewr/nginx_passenger-cookbook"
-issues_url       "https://github.com/ewr/nginx_passenger-cookbook/issues"
 description      "Installs/Configures nginx and Passenger on Ubuntu"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.5.7"

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -72,6 +72,7 @@ http {
   passenger_min_instances <%= node.nginx_passenger.min_instances %>;
   passenger_pool_idle_time <%= node.nginx_passenger.pool_idle_time %>;
   passenger_max_requests <%= node.nginx_passenger.max_requests %>;
+  passenger_log_file <%= node.nginx_passenger.log_file %>;
 
   # -- Logging Format -- #
 


### PR DESCRIPTION
It's useful when you don't wont to see all application's `stdout` or `stderr` on `nginx/error.log`
