### PR TITLE
Making keepalive_timeout a variable instead of hard coded in configuration

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,3 +25,4 @@ default.nginx_passenger.default_log_format    = "combined"
 
 default.nginx_passenger.maintenance_page      = nil
 default.nginx_passenger.maintenance_check     = nil
+default.nginx_passenger.keepalive_timeout     = 65

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,3 +26,7 @@ default.nginx_passenger.default_log_format    = "combined"
 default.nginx_passenger.maintenance_page      = nil
 default.nginx_passenger.maintenance_check     = nil
 default.nginx_passenger.keepalive_timeout     = 65
+default.nginx_passenger.proxy_connect_timeout = 65
+default.nginx_passenger.proxy_send_timeout    = 65
+default.nginx_passenger.proxy_read_timeout    = 65
+default.nginx_passenger.send_timeout          = 65

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -23,6 +23,11 @@ http {
 	tcp_nopush on;
 	tcp_nodelay on;
 	keepalive_timeout <%= node.nginx_passenger.keepalive_timeout %>;
+  proxy_connect_timeout       <%= node.nginx_passenger.proxy_connect_timeout %>;
+  proxy_send_timeout          <%= node.nginx_passenger.proxy_send_timeout %>;
+  proxy_read_timeout          <%= node.nginx_passenger.proxy_read_timeout %>;
+  send_timeout               <%= node.nginx_passenger.send_timeout %>;
+
 	types_hash_max_size 2048;
 	# server_tokens off;
 

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -22,7 +22,7 @@ http {
 	sendfile on;
 	tcp_nopush on;
 	tcp_nodelay on;
-	keepalive_timeout 65;
+	keepalive_timeout <%= node.nginx_passenger.keepalive_timeout %>;
 	types_hash_max_size 2048;
 	# server_tokens off;
 


### PR DESCRIPTION
Making a hardcoded value a variable.
