### PR TITLE
honor nginx user

### DIFF
--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -1,6 +1,6 @@
 # THIS FILE IS MANAGED BY CHEF's nginx_passenger COOKBOOK.
 
-user www-data;
+user <%= node.nginx.user %>;
 worker_processes <%= node.nginx_passenger.nginx_workers %>;
 pid /var/run/nginx.pid;
 


### PR DESCRIPTION
Allow the user to specify `nginx.user` in nginx.conf template. (re-implementing functionality provided by base `nginx` cookbook)
